### PR TITLE
secril-client: close fds on I/O errors

### DIFF
--- a/ril/libsecril-client/secril-client.cpp
+++ b/ril/libsecril-client/secril-client.cpp
@@ -1132,6 +1132,12 @@ error:
     FreeToken(&(client_prv->token_pool), token);
     ClearReqHistory(client_prv, token);
 
+    if (ret == -EPIPE || ret == -EBADFD) {
+        close(client_prv->sock);
+        client_prv->sock = -1;
+        client_prv->b_connect = 0;
+    }
+
     return RIL_CLIENT_ERR_UNKNOWN;
 }
 
@@ -1288,6 +1294,23 @@ static void * RxReaderFunc(void *param) {
                     client_prv->sock = -1;
                     client_prv->b_connect = 0;
                 }
+            }
+        } else {
+            RLOGE("%s: select() returned %d\n", __FUNCTION__, -errno);
+
+            if (client_prv->sock > 0) {
+                close(client_prv->sock);
+                client_prv->sock = -1;
+                client_prv->b_connect = 0;
+            }
+
+            if (client_prv->p_rs)
+                record_stream_free(client_prv->p_rs);
+
+            // EOS
+            if (client_prv->err_cb) {
+                client_prv->err_cb(client_prv->err_cb_data, RIL_CLIENT_ERR_CONNECT);
+                return NULL;
             }
         }
     }


### PR DESCRIPTION
if a kernel device returns an I/O error, it is better not to chew
the CPU resources retrying I/O operation on a not ready device.

Fixes periodical 100%-core load in audioserver after a voice call
completion.

Change-Id: I2b66ffd18c85823a11e50598a6b4e3c0245a0083